### PR TITLE
chore: Adds dependabot support for automated dependency management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2023 Canonical Ltd.
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## Description

This PR adds dependabot support for automating dependency management, just like it is done in other SD-Core repos like the [AMF](https://github.com/omec-project/amf) and [NRF](https://github.com/omec-project/nrf). Dependabot will automatically create pull requests, all we have to do is review and merge those.

## Rationale

Managing dependencies is critical for stability and security purposes and it's very difficult to stay up to date on a best effort basis. 