### PR TITLE
chore: enable all go vet analyzers in CI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -155,8 +155,6 @@ linters-settings:
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
     # enable all analyzers
     enable-all: true
-    disable:
-      - fieldalignment
   depguard:
     list-type: blacklist
     include-go-root: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -153,13 +153,10 @@ linters-settings:
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
-    # enable or disable analyzers by name
-    enable:
-      - atomicalign
-    enable-all: false
+    # enable all analyzers
+    enable-all: true
     disable:
-      - shadow
-    disable-all: false
+      - fieldalignment
   depguard:
     list-type: blacklist
     include-go-root: false

--- a/context/context.go
+++ b/context/context.go
@@ -16,18 +16,18 @@ import (
 type AUSFContext struct {
 	suciSupiMap  sync.Map
 	UePool       sync.Map
+	snRegex      *regexp.Regexp
 	NfId         string
 	GroupID      string
-	SBIPort      int
 	RegisterIPv4 string
 	BindingIPv4  string
 	Url          string
-	UriScheme    models.UriScheme
 	NrfUri       string
+	UdmUeauUrl   string
+	UriScheme    models.UriScheme
 	NfService    map[models.ServiceName]models.NfService
 	PlmnList     []models.PlmnId
-	UdmUeauUrl   string
-	snRegex      *regexp.Regexp
+	SBIPort      int
 }
 
 type AusfUeContext struct {

--- a/factory/config.go
+++ b/factory/config.go
@@ -39,8 +39,8 @@ type Configuration struct {
 	Sbi             *Sbi            `yaml:"sbi,omitempty"`
 	ServiceNameList []string        `yaml:"serviceNameList,omitempty"`
 	NrfUri          string          `yaml:"nrfUri,omitempty"`
-	PlmnSupportList []models.PlmnId `yaml:"plmnSupportList,omitempty"`
 	GroupId         string          `yaml:"groupId,omitempty"`
+	PlmnSupportList []models.PlmnId `yaml:"plmnSupportList,omitempty"`
 }
 
 type Sbi struct {


### PR DESCRIPTION
go vet lint is already enabled in CI.
This PR enables all  go vet analyzers.