### PR TITLE
chore: Move http_wrapper dependency to util project

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/omec-project/config5g v1.2.0
 	github.com/omec-project/http2_util v1.1.0
-	github.com/omec-project/http_wrapper v1.1.0
 	github.com/omec-project/logger_util v1.1.0
 	github.com/omec-project/openapi v1.1.0
 	github.com/omec-project/path_util v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -196,8 +196,6 @@ github.com/omec-project/config5g v1.2.0 h1:fyIg+1LZ9jn8DTkVUbD4jyxA4FgMICdIBwZVn
 github.com/omec-project/config5g v1.2.0/go.mod h1:AWFzCbbgCBx/iJwt+zWbpDGLHRpFzg24OYHqIkdcMVA=
 github.com/omec-project/http2_util v1.1.0 h1:8H2NME/V8iONth8TlyK/3w4pguAzaeUnEv9pmeAocwQ=
 github.com/omec-project/http2_util v1.1.0/go.mod h1:QwoZRaUyhEp/kTEqXvf0gCYtfQrNHBdkVw939vsMjZY=
-github.com/omec-project/http_wrapper v1.1.0 h1:2hD8RUaR/VVg3tUUfuxsuo1/JNpZLiAE8IvATGqDME4=
-github.com/omec-project/http_wrapper v1.1.0/go.mod h1:mc045fjVVJ0/q0g4QG4nuSC0N1BIqGR/ZoK76XgifVU=
 github.com/omec-project/logger_conf v1.1.0 h1:C0/HbsSOWV8D3/lm7Iqe1nUL9ltVtVO4MDC9ZxIo/xc=
 github.com/omec-project/logger_conf v1.1.0/go.mod h1:2+SOX9OFbPZ+UNv8k+tvPnaWHo4CuX5G/x12dz5sWUE=
 github.com/omec-project/logger_util v1.1.0 h1:R7tT80+ML1HlK4OoTrNv/UK+2H/u2GdIFNBx41g630Q=

--- a/producer/ue_authentication.go
+++ b/producer/ue_authentication.go
@@ -21,8 +21,8 @@ import (
 	"github.com/google/gopacket/layers"
 	ausf_context "github.com/omec-project/ausf/context"
 	"github.com/omec-project/ausf/logger"
-	"github.com/omec-project/http_wrapper"
 	"github.com/omec-project/openapi/models"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/util/ueauth"
 )
 
@@ -41,7 +41,7 @@ func GenerateRandomNumber() (uint8, error) {
 	return uint8(randomNumber.Int64()), nil
 }
 
-func HandleEapAuthComfirmRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleEapAuthComfirmRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.Auth5gAkaComfirmLog.Infof("EapAuthComfirmRequest")
 
 	updateEapSession := request.Body.(models.EapSession)
@@ -50,36 +50,36 @@ func HandleEapAuthComfirmRequest(request *http_wrapper.Request) *http_wrapper.Re
 	response, problemDetails := EapAuthComfirmRequestProcedure(updateEapSession, eapSessionID)
 
 	if response != nil {
-		return http_wrapper.NewResponse(http.StatusOK, nil, response)
+		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
-	return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
-func HandleAuth5gAkaComfirmRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleAuth5gAkaComfirmRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.Auth5gAkaComfirmLog.Infof("Auth5gAkaComfirmRequest")
 	updateConfirmationData := request.Body.(models.ConfirmationData)
 	ConfirmationDataResponseID := request.Params["authCtxId"]
 
 	response, problemDetails := Auth5gAkaComfirmRequestProcedure(updateConfirmationData, ConfirmationDataResponseID)
 	if response != nil {
-		return http_wrapper.NewResponse(http.StatusOK, nil, response)
+		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
-	return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
-func HandleUeAuthPostRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleUeAuthPostRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.UeAuthPostLog.Infof("HandleUeAuthPostRequest")
 	updateAuthenticationInfo := request.Body.(models.AuthenticationInfo)
 
@@ -88,15 +88,15 @@ func HandleUeAuthPostRequest(request *http_wrapper.Request) *http_wrapper.Respon
 	respHeader.Set("Location", locationURI)
 
 	if response != nil {
-		return http_wrapper.NewResponse(http.StatusCreated, respHeader, response)
+		return httpwrapper.NewResponse(http.StatusCreated, respHeader, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
-	return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
 // func UeAuthPostRequestProcedure(updateAuthenticationInfo models.AuthenticationInfo) (

--- a/ueauthentication/api_default.go
+++ b/ueauthentication/api_default.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/omec-project/ausf/logger"
 	"github.com/omec-project/ausf/producer"
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 )
@@ -56,7 +56,7 @@ func HTTPEapAuthMethod(ctx *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(ctx.Request, eapSessionReq)
+	req := httpwrapper.NewRequest(ctx.Request, eapSessionReq)
 	req.Params["authCtxId"] = ctx.Param("authCtxId")
 
 	rsp := producer.HandleEapAuthComfirmRequest(req)
@@ -105,7 +105,7 @@ func HTTPUeAuthenticationsAuthCtxID5gAkaConfirmationPut(ctx *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(ctx.Request, confirmationData)
+	req := httpwrapper.NewRequest(ctx.Request, confirmationData)
 	req.Params["authCtxId"] = ctx.Param("authCtxId")
 
 	rsp := producer.HandleAuth5gAkaComfirmRequest(req)
@@ -154,7 +154,7 @@ func HTTPUeAuthenticationsPost(ctx *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(ctx.Request, authInfo)
+	req := httpwrapper.NewRequest(ctx.Request, authInfo)
 
 	rsp := producer.HandleUeAuthPostRequest(req)
 


### PR DESCRIPTION
Moves the `http_wrapper` dependency to the `util` project. Tested with a successful `gnbsim` simulation.