### PR TITLE
chore: Parameterise webui URL

### DIFF
--- a/factory/config.go
+++ b/factory/config.go
@@ -39,6 +39,7 @@ type Configuration struct {
 	Sbi             *Sbi            `yaml:"sbi,omitempty"`
 	ServiceNameList []string        `yaml:"serviceNameList,omitempty"`
 	NrfUri          string          `yaml:"nrfUri,omitempty"`
+	WebuiUri        string          `yaml:"webuiUri"`
 	GroupId         string          `yaml:"groupId,omitempty"`
 	PlmnSupportList []models.PlmnId `yaml:"plmnSupportList,omitempty"`
 }

--- a/factory/factory.go
+++ b/factory/factory.go
@@ -30,6 +30,9 @@ func InitConfigFactory(f string) error {
 		if yamlErr := yaml.Unmarshal(content, &AusfConfig); yamlErr != nil {
 			return yamlErr
 		}
+		if AusfConfig.Configuration.WebuiUri == "" {
+			AusfConfig.Configuration.WebuiUri = "webui:9876"
+		}
 	}
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gin-gonic/gin v1.9.1
 	github.com/google/gopacket v1.1.19
 	github.com/google/uuid v1.6.0
-	github.com/omec-project/config5g v1.3.0
+	github.com/omec-project/config5g v1.3.1
 	github.com/omec-project/http2_util v1.2.0
 	github.com/omec-project/logger_util v1.2.0
 	github.com/omec-project/openapi v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy/FJl/rCYT0+EuS8+Z0z4=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
-github.com/omec-project/config5g v1.3.0 h1:e/oMZlQsef8bOpHT56uAMKIag3epCOW0jpmyadFC+30=
-github.com/omec-project/config5g v1.3.0/go.mod h1:h6eaDdWEY7432L9rZAg1Za6HrvFvDWRNolAn5GK/5No=
+github.com/omec-project/config5g v1.3.1 h1:hSvFHXh/J0mslsWR82PPnmpF0WzkmLa6AOdvEPve9e8=
+github.com/omec-project/config5g v1.3.1/go.mod h1:lN/Jc2BZkE/smOGPCXxeo1dJ7s+s9Wgp34crNLH4YeE=
 github.com/omec-project/http2_util v1.2.0 h1:ggQ1GjY2x6VRpKuRhZj0t9dh6eISY6LRBv4rlMD++8s=
 github.com/omec-project/http2_util v1.2.0/go.mod h1:KLgvU3o7qmG/i5XO/qITscFql2tWCAmjE6glX+dxe7M=
 github.com/omec-project/logger_conf v1.1.1 h1:qo0cF5gnPfth8wy+I/QjiOx+F5jB6h4GLSOdyS+ted8=

--- a/service/init.go
+++ b/service/init.go
@@ -103,7 +103,7 @@ func (ausf *AUSF) Initialize(c *cli.Context) error {
 	roc := os.Getenv("MANAGED_BY_CONFIG_POD")
 	if roc == "true" {
 		initLog.Infoln("MANAGED_BY_CONFIG_POD is true")
-		commChannel := client.ConfigWatcher()
+		commChannel := client.ConfigWatcher(factory.AusfConfig.Configuration.WebuiUri)
 		go ausf.updateConfig(commChannel)
 	} else {
 		go func() {


### PR DESCRIPTION
Config5g library was including the hard coded Webui URL in ConfigWatcher function which is used by several NFs.
PR: https://github.com/omec-project/config5g/pull/35 in Config5G  library allows to change weburi URL. 
Based on that change [this PR](https://github.com/omec-project/ausf/pull/58) provides to pass the Weburi URL in AUSF. 

Note: https://github.com/omec-project/config5g/pull/35 should be merged before this PR.

