### PR TITLE
feat: parametrize paths for TLS certificate and private key

### DIFF
--- a/context/ausf_context_init.go
+++ b/context/ausf_context_init.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/omec-project/ausf/factory"
 	"github.com/omec-project/ausf/logger"
+	"github.com/omec-project/ausf/util"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/util/path_util"
 )
@@ -41,6 +42,8 @@ func InitAusfContext(context *AUSFContext) {
 	context.UriScheme = models.UriScheme(configuration.Sbi.Scheme) // default uri scheme
 	context.RegisterIPv4 = factory.AUSF_DEFAULT_IPV4               // default localhost
 	context.SBIPort = factory.AUSF_DEFAULT_PORT_INT                // default port
+	context.Key = util.AusfKeyPath                                 // default key path
+	context.PEM = util.AusfPemPath                                 // default PEM path
 	if sbi != nil {
 		if sbi.RegisterIPv4 != "" {
 			context.RegisterIPv4 = sbi.RegisterIPv4
@@ -55,8 +58,12 @@ func InitAusfContext(context *AUSFContext) {
 			context.UriScheme = models.UriScheme_HTTP
 		}
 		if tls := sbi.TLS; tls != nil {
-			context.Key = tls.Key
-			context.PEM = tls.PEM
+			if tls.Key != "" {
+				context.Key = tls.Key
+			}
+			if tls.PEM != "" {
+				context.PEM = tls.PEM
+			}
 		}
 
 		context.BindingIPv4 = os.Getenv(sbi.BindingIPv4)

--- a/context/ausf_context_init.go
+++ b/context/ausf_context_init.go
@@ -54,6 +54,10 @@ func InitAusfContext(context *AUSFContext) {
 		} else {
 			context.UriScheme = models.UriScheme_HTTP
 		}
+		if tls := sbi.TLS; tls != nil {
+			context.Key = tls.Key
+			context.PEM = tls.PEM
+		}
 
 		context.BindingIPv4 = os.Getenv(sbi.BindingIPv4)
 		if context.BindingIPv4 != "" {

--- a/context/context.go
+++ b/context/context.go
@@ -25,11 +25,11 @@ type AUSFContext struct {
 	NrfUri       string
 	UdmUeauUrl   string
 	UriScheme    models.UriScheme
+	Key          string
+	PEM          string
 	NfService    map[models.ServiceName]models.NfService
 	PlmnList     []models.PlmnId
 	SBIPort      int
-	Key          string
-	PEM          string
 }
 
 type AusfUeContext struct {

--- a/context/context.go
+++ b/context/context.go
@@ -28,6 +28,8 @@ type AUSFContext struct {
 	NfService    map[models.ServiceName]models.NfService
 	PlmnList     []models.PlmnId
 	SBIPort      int
+	Key          string
+	PEM          string
 }
 
 type AusfUeContext struct {

--- a/factory/ausfcfg.yaml
+++ b/factory/ausfcfg.yaml
@@ -9,6 +9,9 @@ configuration:
     port: 29509
     registerIPv4: 1.1.1.1
     scheme: https
+    tls: # the local path of TLS key
+      key: free5gc/support/TLS/ausf.pem # AUSF TLS Certificate
+      pem: free5gc/support/TLS/ausf.pem # AUSF TLS Private key
   serviceNameList:
     - nausf-auth
 info:

--- a/factory/ausfcfg.yaml
+++ b/factory/ausfcfg.yaml
@@ -10,8 +10,8 @@ configuration:
     registerIPv4: 1.1.1.1
     scheme: https
     tls: # the local path of TLS key
-      key: free5gc/support/TLS/ausf.pem # AUSF TLS Certificate
-      pem: free5gc/support/TLS/ausf.pem # AUSF TLS Private key
+      key: /support/TLS/ausf.pem # AUSF TLS Certificate
+      pem: /support/TLS/ausf.pem # AUSF TLS Private key
   serviceNameList:
     - nausf-auth
 info:

--- a/factory/config.go
+++ b/factory/config.go
@@ -46,9 +46,15 @@ type Configuration struct {
 
 type Sbi struct {
 	Scheme       string `yaml:"scheme"`
+	TLS          *TLS   `yaml:"tls"`
 	RegisterIPv4 string `yaml:"registerIPv4,omitempty"` // IP that is registered at NRF.
 	BindingIPv4  string `yaml:"bindingIPv4,omitempty"`  // IP used to run the server in the node.
 	Port         int    `yaml:"port,omitempty"`
+}
+
+type TLS struct {
+	PEM string `yaml:"pem,omitempty"`
+	Key string `yaml:"key,omitempty"`
 }
 
 type Security struct {

--- a/service/init.go
+++ b/service/init.go
@@ -258,10 +258,12 @@ func (ausf *AUSF) Start() {
 	}
 
 	serverScheme := factory.AusfConfig.Configuration.Sbi.Scheme
+	ausfPemPath := path_util.Free5gcPath(factory.AusfConfig.Configuration.Sbi.TLS.PEM)
+	ausfKeyPath := path_util.Free5gcPath(factory.AusfConfig.Configuration.Sbi.TLS.Key)
 	if serverScheme == "http" {
 		err = server.ListenAndServe()
 	} else if serverScheme == "https" {
-		err = server.ListenAndServeTLS(util.AusfPemPath, util.AusfKeyPath)
+		err = server.ListenAndServeTLS(ausfPemPath, ausfKeyPath)
 	}
 
 	if err != nil {

--- a/service/init.go
+++ b/service/init.go
@@ -258,8 +258,8 @@ func (ausf *AUSF) Start() {
 	}
 
 	serverScheme := factory.AusfConfig.Configuration.Sbi.Scheme
-	ausfPemPath := path_util.Free5gcPath(factory.AusfConfig.Configuration.Sbi.TLS.PEM)
-	ausfKeyPath := path_util.Free5gcPath(factory.AusfConfig.Configuration.Sbi.TLS.Key)
+	ausfPemPath := factory.AusfConfig.Configuration.Sbi.TLS.PEM
+	ausfKeyPath := factory.AusfConfig.Configuration.Sbi.TLS.Key
 	if serverScheme == "http" {
 		err = server.ListenAndServe()
 	} else if serverScheme == "https" {

--- a/service/init.go
+++ b/service/init.go
@@ -258,12 +258,10 @@ func (ausf *AUSF) Start() {
 	}
 
 	serverScheme := factory.AusfConfig.Configuration.Sbi.Scheme
-	ausfPemPath := factory.AusfConfig.Configuration.Sbi.TLS.PEM
-	ausfKeyPath := factory.AusfConfig.Configuration.Sbi.TLS.Key
 	if serverScheme == "http" {
 		err = server.ListenAndServe()
 	} else if serverScheme == "https" {
-		err = server.ListenAndServeTLS(ausfPemPath, ausfKeyPath)
+		err = server.ListenAndServeTLS(self.PEM, self.Key)
 	}
 
 	if err != nil {


### PR DESCRIPTION
This PR enables to set custom paths for TLS certificate and private key.
This PR adds a `tls` container, composed of `pem` and `key` keys, inside `sbi` container to specify the paths of TLS certificate and private key to use for the HTTPS server.