### PR TITLE
feat: add UE authentication metrics

### DIFF
--- a/metrics/telemetry.go
+++ b/metrics/telemetry.go
@@ -11,8 +11,40 @@ import (
 	"net/http"
 
 	"github.com/omec-project/ausf/logger"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
+
+// AusfStats captures AUSF stats
+type AusfStats struct {
+	ueAuths *prometheus.CounterVec
+}
+
+var ausfStats *AusfStats
+
+func initAusfStats() *AusfStats {
+	return &AusfStats{
+		ueAuths: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "ausf_ue_authentications_total",
+			Help: "Counter of total UE Authentications",
+		}, []string{"ausf_id", "serving_network_name", "auth_type", "result"}),
+	}
+}
+
+func (ps *AusfStats) register() error {
+	if err := prometheus.Register(ps.ueAuths); err != nil {
+		return err
+	}
+	return nil
+}
+
+func init() {
+	ausfStats = initAusfStats()
+
+	if err := ausfStats.register(); err != nil {
+		logger.InitLog.Panicln("AUSF Stats register failed")
+	}
+}
 
 // InitMetrics initialises AUSF metrics
 func InitMetrics() {
@@ -20,4 +52,9 @@ func InitMetrics() {
 	if err := http.ListenAndServe(":8080", nil); err != nil {
 		logger.InitLog.Errorf("Could not open metrics port: %v", err)
 	}
+}
+
+// IncrementUeAuthStats increments number of total UE authentications
+func IncrementUeAuthStats(ausfID, servingNetworkName, authType, result string) {
+	ausfStats.ueAuths.WithLabelValues(ausfID, servingNetworkName, authType, result).Inc()
 }

--- a/producer/ue_authentication.go
+++ b/producer/ue_authentication.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/gopacket/layers"
 	ausf_context "github.com/omec-project/ausf/context"
 	"github.com/omec-project/ausf/logger"
+	stats "github.com/omec-project/ausf/metrics"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/util/ueauth"
@@ -88,8 +89,10 @@ func HandleUeAuthPostRequest(request *httpwrapper.Request) *httpwrapper.Response
 	respHeader.Set("Location", locationURI)
 
 	if response != nil {
+		stats.IncrementUeAuthStats(ausf_context.GetSelf().NfId, response.ServingNetworkName, string(response.AuthType), "ok")
 		return httpwrapper.NewResponse(http.StatusCreated, respHeader, response)
 	} else if problemDetails != nil {
+		stats.IncrementUeAuthStats(ausf_context.GetSelf().NfId, updateAuthenticationInfo.ServingNetworkName, "", problemDetails.Cause)
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{

--- a/producer/ue_authentication.go
+++ b/producer/ue_authentication.go
@@ -89,7 +89,7 @@ func HandleUeAuthPostRequest(request *httpwrapper.Request) *httpwrapper.Response
 	respHeader.Set("Location", locationURI)
 
 	if response != nil {
-		stats.IncrementUeAuthStats(ausf_context.GetSelf().NfId, response.ServingNetworkName, string(response.AuthType), "ok")
+		stats.IncrementUeAuthStats(ausf_context.GetSelf().NfId, response.ServingNetworkName, string(response.AuthType), "AUTHORIZED")
 		return httpwrapper.NewResponse(http.StatusCreated, respHeader, response)
 	} else if problemDetails != nil {
 		stats.IncrementUeAuthStats(ausf_context.GetSelf().NfId, updateAuthenticationInfo.ServingNetworkName, "", problemDetails.Cause)
@@ -99,6 +99,7 @@ func HandleUeAuthPostRequest(request *httpwrapper.Request) *httpwrapper.Response
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
+	stats.IncrementUeAuthStats(ausf_context.GetSelf().NfId, updateAuthenticationInfo.ServingNetworkName, "", problemDetails.Cause)
 	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 


### PR DESCRIPTION
This PR adds a new 5G specific metric, `ausf_ue_authentications_total`, to exported metrics via Prometheus.
This metric includes the ID of the NF (AUSF), the serving network name, the authentication type (`5G_AKA`, `EAP_AKA_PRIME`, `EAP_TLS`) and the result. The result may includes details when not successful (e.g., `AV_GENERATION_PROBLEM`, `UPSTREAM_SERVER_ERROR`, `SERVING_NETWORK_NOT_AUTHORIZED`).