### PR TITLE
chore: enable staticcheck and govet in CI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,15 +20,14 @@ linters:
     - goconst
     - godox
     - gomodguard
+    - govet
     - misspell
     - nakedret
     - noctx
     - predeclared
+    - staticcheck
     - unconvert
     - whitespace
-  disable:
-    - govet
-    - staticcheck
   settings:
     errcheck:
       check-type-assertions: false
@@ -62,6 +61,8 @@ linters:
         - XXX
     govet:
       enable-all: true
+      disable:
+        - fieldalignment
       settings:
         printf:
           funcs:

--- a/producer/functions.go
+++ b/producer/functions.go
@@ -218,14 +218,15 @@ func decodeResMac(packetData []byte, wholePacket []byte, Kautn string) ([]byte, 
 		attributeLength = int(uint(dataArray[1+i])) * 4
 		attributeType = int(uint(dataArray[0+i]))
 
-		if attributeType == ausf_context.AT_RES_ATTRIBUTE {
+		switch attributeType {
+		case ausf_context.AT_RES_ATTRIBUTE:
 			logger.EapAuthComfirmLog.Infoln("Detect AT_RES attribute")
 			detectRes = true
 			resLength := int(uint(dataArray[3+i]) | uint(dataArray[2+i])<<8)
 			RES = dataArray[4+i : 4+i+attributeLength-4]
 			byteRes := padZeros(RES, resLength)
 			RES = byteRes
-		} else if attributeType == ausf_context.AT_MAC_ATTRIBUTE {
+		case ausf_context.AT_MAC_ATTRIBUTE:
 			logger.EapAuthComfirmLog.Infoln("Detect AT_MAC attribute")
 			detectMac = true
 			macStr := string(dataArray[4+i : 20+i])
@@ -235,7 +236,7 @@ func decodeResMac(packetData []byte, wholePacket []byte, Kautn string) ([]byte, 
 			} else {
 				logger.EapAuthComfirmLog.Infoln("check MAC integrity failed")
 			}
-		} else {
+		default:
 			logger.EapAuthComfirmLog.Infof("Detect unknown attribute with type %d\n", attributeType)
 		}
 	}
@@ -315,12 +316,13 @@ func sendAuthResultToUDM(id string, authType models.AuthType, success bool, serv
 }
 
 func logConfirmFailureAndInformUDM(id string, authType models.AuthType, servingNetworkName, errStr, udmUrl string) {
-	if authType == models.AuthType__5_G_AKA {
+	switch authType {
+	case models.AuthType__5_G_AKA:
 		logger.Auth5gAkaComfirmLog.Infoln(errStr)
 		if sendErr := sendAuthResultToUDM(id, authType, false, "", udmUrl); sendErr != nil {
 			logger.Auth5gAkaComfirmLog.Infoln(sendErr.Error())
 		}
-	} else if authType == models.AuthType_EAP_AKA_PRIME {
+	case models.AuthType_EAP_AKA_PRIME:
 		logger.EapAuthComfirmLog.Infoln(errStr)
 		if sendErr := sendAuthResultToUDM(id, authType, false, "", udmUrl); sendErr != nil {
 			logger.EapAuthComfirmLog.Infoln(sendErr.Error())

--- a/producer/ue_authentication.go
+++ b/producer/ue_authentication.go
@@ -175,7 +175,8 @@ func UeAuthPostRequestProcedure(updateAuthenticationInfo models.AuthenticationIn
 
 	locationURI := self.Url + "/nausf-auth/v1/ue-authentications/" + supiOrSuci
 	putLink := locationURI
-	if authInfoResult.AuthType == models.AuthType__5_G_AKA {
+	switch authInfoResult.AuthType {
+	case models.AuthType__5_G_AKA:
 		logger.UeAuthPostLog.Infoln("use 5G AKA auth method")
 		putLink += "/5g-aka-confirmation"
 
@@ -215,7 +216,7 @@ func UeAuthPostRequestProcedure(updateAuthenticationInfo models.AuthenticationIn
 		av5gAka.HxresStar = hxresStar
 
 		responseBody.Var5gAuthData = av5gAka
-	} else if authInfoResult.AuthType == models.AuthType_EAP_AKA_PRIME {
+	case models.AuthType_EAP_AKA_PRIME:
 		logger.UeAuthPostLog.Infoln("use EAP-AKA' auth method")
 		putLink += "/eap-session"
 

--- a/service/init.go
+++ b/service/init.go
@@ -204,7 +204,7 @@ func (ausf *AUSF) updateConfig(commChannel chan *protos.NetworkSliceResponse) bo
 			logger.GrpcLog.Infoln("network Slice Name", ns.Name)
 			if ns.Site != nil {
 				temp := models.PlmnId{}
-				var found bool = false
+				found := false
 				logger.GrpcLog.Infoln("network slice has site name present")
 				site := ns.Site
 				logger.GrpcLog.Infoln("site name", site.SiteName)
@@ -290,9 +290,10 @@ func (ausf *AUSF) Start() {
 	}
 
 	serverScheme := factory.AusfConfig.Configuration.Sbi.Scheme
-	if serverScheme == "http" {
+	switch serverScheme {
+	case "http":
 		err = server.ListenAndServe()
-	} else if serverScheme == "https" {
+	case "https":
 		err = server.ListenAndServeTLS(self.PEM, self.Key)
 	}
 

--- a/service/init.go
+++ b/service/init.go
@@ -295,6 +295,9 @@ func (ausf *AUSF) Start() {
 		err = server.ListenAndServe()
 	case "https":
 		err = server.ListenAndServeTLS(self.PEM, self.Key)
+	default:
+		logger.InitLog.Fatalf("HTTP server setup failed: invalid server scheme %+v", serverScheme)
+		return
 	}
 
 	if err != nil {


### PR DESCRIPTION
This PR enables `staticcheck` and `govet` in the CI. 
govet's fieldalignment is disabled.