### PR TITLE
feat: run E2E tests automatically

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,3 +49,11 @@ jobs:
     uses: omec-project/.github/.github/workflows/unit-test.yml@main
     with:
       branch_name: ${{ github.ref }}
+
+  e2e-tests:
+    if: github.event_name == 'pull_request'
+    uses: omec-project/.github/.github/workflows/e2e-test.yml@main
+    with:
+      branch_name: ${{ github.ref }}
+
+


### PR DESCRIPTION
Run E2E tests as part of CI process. Hence, we make sure that integrations tests will pass without manual testing.