### PR TITLE
fix: heartbeat timer overwrite during NF registration to the NRF

### DIFF
--- a/consumer/nf_management.go
+++ b/consumer/nf_management.go
@@ -1,5 +1,5 @@
 // Copyright 2019 free5GC.org
-// SPDX-FileCopyrightText: 2024 Canonical Ltd.
+// SPDX-FileCopyrightText: 2025 Canonical Ltd.
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -95,7 +95,7 @@ var SendDeregisterNFInstance = func() error {
 	if res == nil {
 		return fmt.Errorf("no response from server")
 	}
-	if res.StatusCode == 204 {
+	if res.StatusCode == http.StatusNoContent {
 		return nil
 	}
 	return fmt.Errorf("unexpected response code")
@@ -125,7 +125,7 @@ var SendUpdateNFInstance = func(patchItem []models.PatchItem) (receivedNfProfile
 	if res == nil {
 		return models.NfProfile{}, nil, fmt.Errorf("no response from server")
 	}
-	if res.StatusCode == 200 || res.StatusCode == 204 {
+	if res.StatusCode == http.StatusOK || res.StatusCode == http.StatusNoContent {
 		return receivedNfProfile, nil, nil
 	}
 	return models.NfProfile{}, nil, fmt.Errorf("unexpected response code")

--- a/nfregistration/nf_registration.go
+++ b/nfregistration/nf_registration.go
@@ -26,8 +26,8 @@ var (
 )
 
 const (
-	DEFAULT_HEARTBEAT_TIMER int32 = 60
-	RETRY_TIME                    = 10 * time.Second
+	defaultHeartbeatTimer int32 = 60
+	retryTime                   = 10 * time.Second
 )
 
 // StartNfRegistrationService starts the registration service. If the new config is empty, the NF
@@ -79,7 +79,7 @@ var registerNF = func(registerCtx context.Context, newPlmnConfig []models.PlmnId
 			nfProfile, _, err := consumer.SendRegisterNFInstance(newPlmnConfig)
 			if err != nil {
 				logger.NrfRegistrationLog.Errorln("register AUSF instance to NRF failed. Will retry.", err.Error())
-				interval = RETRY_TIME
+				interval = retryTime
 				continue
 			}
 			logger.NrfRegistrationLog.Infoln("register AUSF instance to NRF with updated profile succeeded")
@@ -152,7 +152,7 @@ func startKeepAliveTimer(profileHeartbeatTimer int32, plmnConfig []models.PlmnId
 	keepAliveTimerMutex.Lock()
 	defer keepAliveTimerMutex.Unlock()
 	stopKeepAliveTimer()
-	heartbeatTimer := DEFAULT_HEARTBEAT_TIMER
+	heartbeatTimer := defaultHeartbeatTimer
 	if profileHeartbeatTimer > 0 {
 		heartbeatTimer = profileHeartbeatTimer
 	}

--- a/nfregistration/nf_registration.go
+++ b/nfregistration/nf_registration.go
@@ -22,6 +22,7 @@ var (
 	keepAliveTimer      *time.Timer
 	keepAliveTimerMutex sync.Mutex
 	registerCtxMutex    sync.Mutex
+	afterFunc           = time.AfterFunc
 )
 
 const (
@@ -152,12 +153,12 @@ func startKeepAliveTimer(profileHeartbeatTimer int32, plmnConfig []models.PlmnId
 	defer keepAliveTimerMutex.Unlock()
 	stopKeepAliveTimer()
 	heartbeatTimer := DEFAULT_HEARTBEAT_TIMER
-	if profileHeartbeatTimer <= 0 {
+	if profileHeartbeatTimer > 0 {
 		heartbeatTimer = profileHeartbeatTimer
 	}
 	heartbeatFunction := func() { heartbeatNF(plmnConfig) }
 	// AfterFunc starts timer and waits for keepAliveTimer to elapse and then calls heartbeatNF function
-	keepAliveTimer = time.AfterFunc(time.Duration(heartbeatTimer)*time.Second, heartbeatFunction)
+	keepAliveTimer = afterFunc(time.Duration(heartbeatTimer)*time.Second, heartbeatFunction)
 	logger.NrfRegistrationLog.Debugf("started heartbeat timer: %v sec", heartbeatTimer)
 }
 

--- a/nfregistration/nf_registration_test.go
+++ b/nfregistration/nf_registration_test.go
@@ -133,7 +133,7 @@ func TestNfRegistrationService_ConfigChanged_RetryIfRegisterNFFails(t *testing.T
 	go StartNfRegistrationService(ctx, ch)
 	ch <- []models.PlmnId{{Mcc: "001", Mnc: "01"}}
 
-	time.Sleep(2 * RETRY_TIME)
+	time.Sleep(2 * retryTime)
 
 	if called < 2 {
 		t.Error("Expected to retry register to NRF")


### PR DESCRIPTION
## Description

We want to use the heartbeat time in the NF profile only if it is greater than 0
This PR fixes that and adds an UT

It was not visible because the NRF sends the same heartbeat time as the one we use by default